### PR TITLE
Improve yak packaging

### DIFF
--- a/.github/workflows/yakdeploy.yml
+++ b/.github/workflows/yakdeploy.yml
@@ -26,8 +26,9 @@ jobs:
       - name: Run a multi-line script
         run: |
           curl https://files.mcneel.com/yak/tools/latest/yak.exe -o yak.exe
-          ./yak spec
-          Add-Content -Path .\manifest.yml -Value 'icon_url: https://github.com/arup-group/GSA-Grasshopper/raw/master/GhSA/Properties/GsaGhLogo.png'
-          ./yak build
-          $YAK_FILENAME = dir *.yak 
-          ./yak push $YAK_FILENAME.Name
+          .\yak version
+          cp -v GSA.gha dist\
+          cd dist
+          ..\yak build
+          cd ..
+          ls dist\*.yak |% {.\yak push $_.FullName}

--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,8 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# yak
+yak.exe
+dist/*
+!dist/manifest.yml

--- a/dist/manifest.yml
+++ b/dist/manifest.yml
@@ -1,0 +1,8 @@
+---
+name: GSA
+version: $version
+authors:
+- Oasys
+description: GSA Plugin
+url: https://github.com/arup-group/GSA-Grasshopper
+icon_url: https://raw.githubusercontent.com/arup-group/GSA-Grasshopper/master/GhSA/Properties/GsaGhLogo.png


### PR DESCRIPTION
Copies the GHA into the dist/ directory and builds the package from there, instead of packaging _everything_ in the repository (including the .git directory and a .pptx file at >100 MB).

Adds yak's manifest.yml file to version control. The `$version` placeholder will be replaced with the GHA's version number. This is preferred over running `yak spec` each time.