### PR TITLE
GsaGH-354

### DIFF
--- a/GsaGH/Helpers/GH/RhinoConversions.cs
+++ b/GsaGH/Helpers/GH/RhinoConversions.cs
@@ -561,6 +561,10 @@ namespace GsaGH.Helpers.GH {
               topoInts.Add(topo8);
               break;
             }
+          
+          default: {
+              throw new Exception($" Unable to create 2D element from mesh face with {topo.Count} verticies");
+            }
         }
 
         elem.Property = prop;


### PR DESCRIPTION
throw exception if number of verticies does not match an accepted element type