### PR TITLE
GSAGH-529: Add One Way, Two Way, options on Prop2d

### DIFF
--- a/GsaGH/Components/1_Properties/Create2dProperty.cs
+++ b/GsaGH/Components/1_Properties/Create2dProperty.cs
@@ -43,6 +43,8 @@ namespace GsaGH.Components {
       { Prop2dType.LoadPanel, "Load Panel" },
     };
     private readonly IReadOnlyDictionary<SupportType, string> _supportDropDown = new Dictionary<SupportType, string> {
+      { SupportType.OneWay, "One-way" },
+      { SupportType.TwoWay, "Two-way" },
       { SupportType.Auto, "Automatic" },
       { SupportType.AllEdges, "All edges" },
       { SupportType.ThreeEdges, "Three edges" },
@@ -50,8 +52,6 @@ namespace GsaGH.Components {
       { SupportType.TwoAdjacentEdges, "Two adjacent edges" },
       { SupportType.OneEdge, "One edge" },
       { SupportType.Cantilever, "Cantilever" },
-      { SupportType.OneWay, "One-way" },
-      { SupportType.TwoWay, "Two-way" },
     };
 
     private LengthUnit _lengthUnit = DefaultUnits.LengthUnitSection;
@@ -89,13 +89,10 @@ namespace GsaGH.Components {
 
     private bool IsLegacySupportEdge(Prop2D property2d = null) {
       if (property2d != null) {
-        return property2d.SupportType != SupportType.Auto && property2d.SupportType != SupportType.AllEdges
-          && property2d.SupportType != SupportType.OneWay && property2d.SupportType != SupportType.TwoWay;
+        return property2d.SupportType != SupportType.OneWay && property2d.SupportType != SupportType.TwoWay;
       }
 
-      return _supportTypeIndex != _supportDropDown.Keys.ToList().IndexOf(SupportType.Auto)
-        && _supportTypeIndex != _supportDropDown.Keys.ToList().IndexOf(SupportType.AllEdges)
-        && _supportTypeIndex != _supportDropDown.Keys.ToList().IndexOf(SupportType.OneWay)
+      return  _supportTypeIndex != _supportDropDown.Keys.ToList().IndexOf(SupportType.OneWay)
         && _supportTypeIndex != _supportDropDown.Keys.ToList().IndexOf(SupportType.TwoWay);
     }
 
@@ -126,7 +123,6 @@ namespace GsaGH.Components {
             SetInputProperties(3, "Off", $"Offset [{Length.GetAbbreviation(_lengthUnit)}]", "Additional Offset",
               optional: true);
           }
-
           return;
       }
     }

--- a/GsaGHTests/3_Components/1_Properties/CreateProp2dTests.cs
+++ b/GsaGHTests/3_Components/1_Properties/CreateProp2dTests.cs
@@ -1,4 +1,6 @@
-﻿using GsaGH.Components;
+﻿using GsaAPI;
+
+using GsaGH.Components;
 
 using GsaGHTests.Helpers;
 
@@ -31,7 +33,7 @@ namespace GsaGHTests.Components.Properties {
       var component = new Create2dProperty();
       component.CreateAttributes();
       component.SetSelected(0, 5); // 5-"Load"
-      component.SetSelected(1, 3); // "TwoEdges"
+      component.SetLoadPanelSupportType((SupportType)LoadPanelPropertyTests.LocalSupportType.TwoEdges);
       ComponentTestHelper.SetInput(component, 2, 0);
       return component;
     }

--- a/GsaGHTests/3_Components/1_Properties/LoadPanelPropertyTests.cs
+++ b/GsaGHTests/3_Components/1_Properties/LoadPanelPropertyTests.cs
@@ -9,8 +9,7 @@ using GsaGHTests.Helpers;
 
 using Xunit;
 
-namespace GsaGHTests.Components.Properties
-{
+namespace GsaGHTests.Components.Properties {
   [Collection("GrasshopperFixture collection")]
   public class LoadPanelPropertyTests {
 
@@ -63,8 +62,6 @@ namespace GsaGHTests.Components.Properties
     }
 
     [Theory]
-    [InlineData(LocalSupportType.Auto)]
-    [InlineData(LocalSupportType.AllEdges)]
     [InlineData(LocalSupportType.OneWay)]
     [InlineData(LocalSupportType.TwoWay)]
     public void ShouldNotHaveWarningForLegacy(LocalSupportType supportType) {

--- a/GsaGHTests/3_Components/1_Properties/LoadPanelPropertyTests.cs
+++ b/GsaGHTests/3_Components/1_Properties/LoadPanelPropertyTests.cs
@@ -44,6 +44,8 @@ namespace GsaGHTests.Components.Properties
     }
 
     [Theory]
+    [InlineData(LocalSupportType.Auto)]
+    [InlineData(LocalSupportType.AllEdges)]
     [InlineData(LocalSupportType.ThreeEdges)]
     [InlineData(LocalSupportType.TwoEdges)]
     [InlineData(LocalSupportType.TwoAdjacentEdges)]


### PR DESCRIPTION
Change dropdown order of support type

 { SupportType.OneWay, "One-way" },
 { SupportType.TwoWay, "Two-way" },
 { SupportType.Auto, "Automatic" },
 { SupportType.AllEdges, "All edges" },
 { SupportType.ThreeEdges, "Three edges" },
 { SupportType.TwoEdges, "Two edges" },
 { SupportType.TwoAdjacentEdges, "Two adjacent edges" },
 { SupportType.OneEdge, "One edge" },
 { SupportType.Cantilever, "Cantilever" },