### PR TITLE
GSAGH-606: Ignore wrong topology

### DIFF
--- a/GsaGH/Parameters/2_Geometry/GsaElement1d.cs
+++ b/GsaGH/Parameters/2_Geometry/GsaElement1d.cs
@@ -91,8 +91,9 @@ namespace GsaGH.Parameters {
     /// <summary>
     /// Create a new instance from an API object from an existing model
     /// </summary>
-    internal GsaElement1d(KeyValuePair<int, GSAElement> element, IReadOnlyDictionary<int, Node> nodes,
-      GsaSection section, ReadOnlyCollection<double> localAxes, LengthUnit modelUnit) {
+    internal GsaElement1d(
+      KeyValuePair<int, GSAElement> element, IReadOnlyDictionary<int, Node> nodes, GsaSection section,
+      ReadOnlyCollection<double> localAxes, LengthUnit modelUnit) {
       InitVariables(element, nodes, localAxes, modelUnit);
       Section = section;
     }
@@ -100,8 +101,9 @@ namespace GsaGH.Parameters {
     /// <summary>
     ///   Create a new instance from an API object from an existing model
     /// </summary>
-    internal GsaElement1d(KeyValuePair<int, GSAElement> element, IReadOnlyDictionary<int, Node> nodes,
-      GsaSpringProperty springProperty, ReadOnlyCollection<double> localAxes, LengthUnit modelUnit) {
+    internal GsaElement1d(
+      KeyValuePair<int, GSAElement> element, IReadOnlyDictionary<int, Node> nodes, GsaSpringProperty springProperty,
+      ReadOnlyCollection<double> localAxes, LengthUnit modelUnit) {
       InitVariables(element, nodes, localAxes, modelUnit);
       SpringProperty = springProperty;
     }
@@ -140,12 +142,19 @@ namespace GsaGH.Parameters {
       string type = Mappings._elementTypeMapping.FirstOrDefault(x => x.Value == ApiElement.Type).Key;
       string property = string.Empty;
       if (Section != null) {
-        property = Section.Id > 0 ? $"PB{Section.Id}"
-        : Section.ApiSection != null ? Section.ApiSection.Profile : string.Empty;
+        property = Section.Id > 0 ?
+          $"PB{Section.Id}" :
+          Section.ApiSection != null ?
+            Section.ApiSection.Profile :
+            string.Empty;
       } else if (SpringProperty != null) {
-        property = SpringProperty.Id > 0 ? $"SP{SpringProperty.Id}"
-        : SpringProperty.ApiProperty != null ? SpringProperty.ApiProperty.Name : string.Empty;
+        property = SpringProperty.Id > 0 ?
+          $"SP{SpringProperty.Id}" :
+          SpringProperty.ApiProperty != null ?
+            SpringProperty.ApiProperty.Name :
+            string.Empty;
       }
+
       return string.Join(" ", id, type, property).TrimSpaces();
     }
 
@@ -153,20 +162,17 @@ namespace GsaGH.Parameters {
       Bool6 s = ApiElement.GetEndRelease(0).Releases;
       Bool6 e = ApiElement.GetEndRelease(1).Releases;
 
-      if (s.X || s.Y || s.Z || s.XX || s.YY || s.ZZ
-        || e.X || e.Y || e.Z || e.XX || e.YY || e.ZZ) {
+      if (s.X || s.Y || s.Z || s.XX || s.YY || s.ZZ || e.X || e.Y || e.Z || e.XX || e.YY || e.ZZ) {
         var crv = new PolyCurve();
         crv.Append(Line);
-        ReleasePreview = new ReleasePreview(crv,
-          ApiElement.OrientationAngle * Math.PI / 180.0, s, e);
+        ReleasePreview = new ReleasePreview(crv, ApiElement.OrientationAngle * Math.PI / 180.0, s, e);
       } else {
         ReleasePreview = new ReleasePreview();
       }
     }
 
     private GsaOffset GetOffSetFromApiElement() {
-      return new GsaOffset(
-        ApiElement.Offset.X1, ApiElement.Offset.X2, ApiElement.Offset.Y, ApiElement.Offset.Z);
+      return new GsaOffset(ApiElement.Offset.X1, ApiElement.Offset.X2, ApiElement.Offset.Y, ApiElement.Offset.Z);
     }
 
     private void SetOffsetInApiElement(GsaOffset offset) {
@@ -196,9 +202,14 @@ namespace GsaGH.Parameters {
         OrientationNode = new GsaNode(Nodes.Point3dFromNode(nodes[ApiElement.OrientationNode], modelUnit));
       }
 
-      Line = new LineCurve(new Line(Nodes.Point3dFromNode(nodes[ApiElement.Topology[0]], modelUnit),
-        Nodes.Point3dFromNode(nodes[ApiElement.Topology[1]], modelUnit)));
-      LocalAxes = new LocalAxes(localAxes);
+      if (nodes.TryGetValue(ApiElement.Topology[0], out Node node1)
+        && nodes.TryGetValue(ApiElement.Topology[1], out Node node2)) {
+        {
+          Line = new LineCurve(new Line(Nodes.Point3dFromNode(node1, modelUnit),
+            Nodes.Point3dFromNode(node2, modelUnit)));
+          LocalAxes = new LocalAxes(localAxes);
+        }
+      }
     }
 
     private void SetOffsets(Element elem) {

--- a/GsaGHTests/1_BaseParameters/2_Geometry/GsaElement1dTest.cs
+++ b/GsaGHTests/1_BaseParameters/2_Geometry/GsaElement1dTest.cs
@@ -1,4 +1,8 @@
-﻿using System.Drawing;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing;
+
+using GsaAPI;
 
 using GsaGH.Parameters;
 
@@ -179,6 +183,54 @@ namespace GsaGHTests.Parameters {
 
       var dup = new GsaElement1d(orig);
       Assert.Equal(dup.Section.Guid, orig.Section.Guid);
+    }
+
+
+    [Fact]
+    public void ShouldCreateElementWithNoValidLine() {
+      var gsaElement = new GSAElement(new Element());
+      gsaElement.OrientationNode = 0;
+      gsaElement.Topology = new ReadOnlyCollection<int>(new List<int> { 2, 3 });
+      var element = new KeyValuePair<int, GSAElement>(0, gsaElement);
+      Dictionary<int, Node> nodes = new Dictionary<int, Node>();
+      var  p1 = new Node();
+      p1.Position = new Vector3() { X = 1, Y = 2, Z = 3 };
+      nodes.Add(0,p1 );
+      var  p2 = new Node();
+      p2.Position = new Vector3() { X = 4, Y = 5, Z = 6 };
+      nodes.Add(1, p2);
+
+      ReadOnlyCollection<double> localaxes = new ReadOnlyCollection<double>(new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1 });
+      var section = new GsaSection();
+      var elem = new GsaElement1d(element, nodes, section, localaxes, LengthUnit.Meter);
+
+      Assert.Equal(elem.Line.PointAtStart, elem.Line.PointAtEnd);
+    }
+
+    [Fact]
+    public void ShouldCreateElementWithAValidLine() {
+      var gsaElement = new GSAElement(new Element());
+      gsaElement.OrientationNode = 0;
+      gsaElement.Topology = new ReadOnlyCollection<int>(new List<int> { 0, 1 });
+      var element = new KeyValuePair<int, GSAElement>(0, gsaElement);
+      Dictionary<int, Node> nodes = new Dictionary<int, Node>();
+      var  p1 = new Node();
+      p1.Position = new Vector3() { X = 1, Y = 2, Z = 3 };
+      nodes.Add(0,p1 );
+      var  p2 = new Node();
+      p2.Position = new Vector3() { X = 4, Y = 5, Z = 6 };
+      nodes.Add(1, p2);
+
+      ReadOnlyCollection<double> localaxes = new ReadOnlyCollection<double>(new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1 });
+      var section = new GsaSection();
+      var elem = new GsaElement1d(element, nodes, section, localaxes, LengthUnit.Meter);
+
+      var pos1 = p1.Position;
+      Assert.Equal(elem.Line.PointAtStart, 
+          new Point3d() { X = pos1.X, Y = pos1.Y, Z = pos1.Z });
+      var pos2 = p2.Position;
+      Assert.Equal(elem.Line.PointAtEnd,
+          new Point3d() { X = pos2.X, Y = pos2.Y, Z = pos2.Z });
     }
   }
 }

--- a/GsaGHTests/1_BaseParameters/2_Geometry/GsaElement1dTest.cs
+++ b/GsaGHTests/1_BaseParameters/2_Geometry/GsaElement1dTest.cs
@@ -186,13 +186,13 @@ namespace GsaGHTests.Parameters {
     }
 
 
-    [Fact]
-    public void ShouldCreateElementWithNoValidLine() {
+    public GsaElement1d GetElement(List<int> topo, out  Dictionary<int, Node> nodes)
+    {
       var gsaElement = new GSAElement(new Element());
       gsaElement.OrientationNode = 0;
-      gsaElement.Topology = new ReadOnlyCollection<int>(new List<int> { 2, 3 });
+      gsaElement.Topology = new ReadOnlyCollection<int>(topo);
       var element = new KeyValuePair<int, GSAElement>(0, gsaElement);
-      Dictionary<int, Node> nodes = new Dictionary<int, Node>();
+      nodes = new Dictionary<int, Node>();
       var  p1 = new Node();
       p1.Position = new Vector3() { X = 1, Y = 2, Z = 3 };
       nodes.Add(0,p1 );
@@ -203,32 +203,23 @@ namespace GsaGHTests.Parameters {
       ReadOnlyCollection<double> localaxes = new ReadOnlyCollection<double>(new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1 });
       var section = new GsaSection();
       var elem = new GsaElement1d(element, nodes, section, localaxes, LengthUnit.Meter);
+      return elem;
+    }
 
+    [Fact]
+    public void ShouldCreateElementWithNoValidLine() {
+      var elem = GetElement(new List<int> { 2, 3 }, out var _);
       Assert.Equal(elem.Line.PointAtStart, elem.Line.PointAtEnd);
     }
 
     [Fact]
     public void ShouldCreateElementWithAValidLine() {
-      var gsaElement = new GSAElement(new Element());
-      gsaElement.OrientationNode = 0;
-      gsaElement.Topology = new ReadOnlyCollection<int>(new List<int> { 0, 1 });
-      var element = new KeyValuePair<int, GSAElement>(0, gsaElement);
-      Dictionary<int, Node> nodes = new Dictionary<int, Node>();
-      var  p1 = new Node();
-      p1.Position = new Vector3() { X = 1, Y = 2, Z = 3 };
-      nodes.Add(0,p1 );
-      var  p2 = new Node();
-      p2.Position = new Vector3() { X = 4, Y = 5, Z = 6 };
-      nodes.Add(1, p2);
 
-      ReadOnlyCollection<double> localaxes = new ReadOnlyCollection<double>(new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1 });
-      var section = new GsaSection();
-      var elem = new GsaElement1d(element, nodes, section, localaxes, LengthUnit.Meter);
-
-      var pos1 = p1.Position;
+      var elem = GetElement(new List<int> { 0, 1 }, out var nodes);
+      var pos1 = nodes[0].Position;
       Assert.Equal(elem.Line.PointAtStart, 
           new Point3d() { X = pos1.X, Y = pos1.Y, Z = pos1.Z });
-      var pos2 = p2.Position;
+      var pos2 = nodes[1].Position;
       Assert.Equal(elem.Line.PointAtEnd,
           new Point3d() { X = pos2.X, Y = pos2.Y, Z = pos2.Z });
     }


### PR DESCRIPTION
- **fix(GsaElement1d.cs): make sure node exists before attempting to get retrieve it**
- **test(GsaElement1dTest.cs): added basic tests to show we are ignoring topology if it doesn't exists**
- **test(GsaElement1dTest.cs): simplified the test calls**
