### PR TITLE
GSAGH-652 : 'Create Modal Dynamic parameter' loses its input on reopening the file

### DIFF
--- a/GsaGH/Components/4_Analysis/CreateModalDynamicParameter.cs
+++ b/GsaGH/Components/4_Analysis/CreateModalDynamicParameter.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Drawing;
 
+using GH_IO.Serialization;
+
 using Grasshopper.Kernel;
 
 using GsaAPI;
@@ -22,16 +24,41 @@ namespace GsaGH.Components {
   ///   Component to create a modal dynamic parameter
   /// </summary>
   public class CreateModalDynamicParameter : GH_OasysDropDownComponent {
+    private const string ModeMethodKey = "ModeMethod";
     public override Guid ComponentGuid => new Guid("75bf6454-92c4-4a3c-8abf-75f1d449cb85");
     public override GH_Exposure Exposure => GH_Exposure.tertiary | GH_Exposure.obscure;
     public override OasysPluginInfo PluginInfo => GsaGH.PluginInfo.Instance;
     protected override Bitmap Icon => Resources.CreateModalDynamicParameter;
     private ModeCalculationMethod _modeMethod = ModeCalculationMethod.NumberOfMode;
+    private bool _isReading;
     public CreateModalDynamicParameter() : base(
       $"Create {GsaModalDynamicGoo.Name}",
       GsaModalDynamicGoo.NickName.Replace(" ", string.Empty),
       $"Create {GsaModalDynamicGoo.Description}", CategoryName.Name(), SubCategoryName.Cat4()) {
       Hidden = true;
+    }
+
+    public override bool Read(GH_IReader reader) {
+      bool hasModeMethod = reader.ItemExists(ModeMethodKey);
+      if (hasModeMethod) {
+        _modeMethod = (ModeCalculationMethod)reader.GetInt32(ModeMethodKey);
+      }
+
+      _isReading = true;
+      bool flag = base.Read(reader);
+      _isReading = false;
+
+      if (!hasModeMethod && _selectedItems.Count > 0) {
+        _modeMethod = GetModeStrategy(_selectedItems[0]);
+      }
+
+      RefreshInputParametersForMode();
+      return flag;
+    }
+
+    public override bool Write(GH_IWriter writer) {
+      writer.SetInt32(ModeMethodKey, (int)_modeMethod);
+      return base.Write(writer);
     }
 
     private static readonly IReadOnlyDictionary<ModeCalculationMethod, string> _modeCalculationMethod
@@ -268,6 +295,28 @@ namespace GsaGH.Components {
     }
 
     public override void VariableParameterMaintenance() {
+      if (_isReading) {
+        return;
+      }
+
+      RefreshInputParametersForMode();
+    }
+
+    private int GetRequiredInputCount() {
+      return _modeMethod switch {
+        ModeCalculationMethod.NumberOfMode => 5,
+        ModeCalculationMethod.FrquencyRange => 7,
+        ModeCalculationMethod.TargetMassRatio => 9,
+        _ => 5,
+      };
+    }
+
+    private void RefreshInputParametersForMode() {
+      // Keep deserialized parameters and their sources if the input layout already matches.
+      if (Params.Input.Count == GetRequiredInputCount()) {
+        return;
+      }
+
       UnregisterParameters();
       int index = 0;
       if (_modeMethod == ModeCalculationMethod.NumberOfMode) {

--- a/GsaGHTests/3_Components/4_Analysis/CreateModalDynamicParameterTests.cs
+++ b/GsaGHTests/3_Components/4_Analysis/CreateModalDynamicParameterTests.cs
@@ -5,6 +5,8 @@ using GH_IO.Serialization;
 
 using Grasshopper.GUI.HTML;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using Grasshopper.Kernel.Types;
 
 using GsaAPI;
 
@@ -608,6 +610,59 @@ namespace GsaGHTests.Components.Analysis {
       Assert.Equal(original.SelectedItems[1], loadedComponent.SelectedItems[1]);
       Assert.Equal(original.SelectedItems[2], loadedComponent.SelectedItems[2]);
 
+    }
+
+    [Fact]
+    public void ShouldPreserveInputConnectionsAfterSerializeAndDeserialize() {
+      var original = new CreateModalDynamicParameter();
+      original.CreateAttributes();
+      original.SetSelected(0, 2);
+
+      var doc = new GH_DocumentIO {
+        Document = new GH_Document()
+      };
+
+      // Create document-owned source params so connections can be serialized.
+      var sourceX = new Param_Number();
+      sourceX.CreateAttributes();
+      sourceX.PersistentData.Append(new GH_Number(90.0));
+
+      var sourceY = new Param_Number();
+      sourceY.CreateAttributes();
+      sourceY.PersistentData.Append(new GH_Number(95.0));
+
+      var sourceLoadCase = new Param_String();
+      sourceLoadCase.CreateAttributes();
+      sourceLoadCase.PersistentData.Append(new GH_String("L1"));
+
+      var sourceDamping = new Param_Number();
+      sourceDamping.CreateAttributes();
+      sourceDamping.PersistentData.Append(new GH_Number(0.15));
+
+      doc.Document.AddObject(sourceX, false);
+      doc.Document.AddObject(sourceY, false);
+      doc.Document.AddObject(sourceLoadCase, false);
+      doc.Document.AddObject(sourceDamping, false);
+      doc.Document.AddObject(original, false);
+
+      original.Params.Input[0].AddSource(sourceX);
+      original.Params.Input[1].AddSource(sourceY);
+      original.Params.Input[5].AddSource(sourceLoadCase);
+      original.Params.Input[8].AddSource(sourceDamping);
+
+      int[] sourceCountsBefore = original.Params.Input.Select(x => x.SourceCount).ToArray();
+
+      string randomPath = GetRandomPath();
+      Assert.True(doc.SaveQuiet(randomPath));
+      Assert.True(doc.Open(randomPath));
+
+      var loadedComponent = (CreateModalDynamicParameter)doc.Document.FindComponent(original.InstanceGuid);
+      Assert.NotNull(loadedComponent);
+      Assert.Equal(sourceCountsBefore.Length, loadedComponent.Params.Input.Count);
+
+      for (int i = 0; i < sourceCountsBefore.Length; i++) {
+        Assert.Equal(sourceCountsBefore[i], loadedComponent.Params.Input[i].SourceCount);
+      }
     }
   }
 }


### PR DESCRIPTION
Previously, VariableParameterMaintenance always use to unregister and recreated all inputs, which resulted into drop source wiring during document load.

Now it does not rebuilds parameter when file is being read and also when input count match the active mode count on opening